### PR TITLE
do not depend on Oscar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"

--- a/src/GenericDecMats.jl
+++ b/src/GenericDecMats.jl
@@ -58,7 +58,7 @@ module GenericDecMats
 
 using Markdown
 using JSON
-using Oscar
+using Requires
 
 import Base.show
 
@@ -67,132 +67,6 @@ export generic_decomposition_matrix,
 
 # The data files are stored in this directory.
 const _datadir = abspath(@__DIR__, "..", "data")
-
-mutable struct GenericDecompositionMatrix
-    # parameters
-    type::String
-    n::Int
-    d::Int
-    # row and column labels
-    ordinary::Vector{String}
-    hc_series::Vector{String}
-    # distribution of rows (ordinary) to blocks
-    blocks::Vector{Tuple{String, String, Int}}
-    blocklabels::Vector{Int}
-    # dec. matrix and its entries
-    R::Union{MPolyRing{fmpz}, FlintIntegerRing}
-    vars::Union{Vector{fmpz_mpoly}, Vector{fmpz}}
-    decmat::Union{AbstractAlgebra.Generic.MatSpaceElem{fmpz_mpoly},fmpz_mat}
-    # exclude some values of q if necessary
-    condition::String
-    # bibliographical information
-    origin::String
-end
-
-"""
-    generic_decomposition_matrix(type::String, n::Int, d::Int)
-    generic_decomposition_matrix(name::String)
-
-Return the object described by the inputs if it is available,
-and `nothing` otherwise.
-"""
-function generic_decomposition_matrix(type::String, n::Int, d::Int)
-    return generic_decomposition_matrix(type*string(n)*"d"*string(d))
-end
-
-# load from file if available
-function generic_decomposition_matrix(name::String)
-    filename = _datadir*"/"*name*".json"
-    isfile(filename) || return nothing
-    str = read(filename, String)
-    prs = JSON.parse(str; dicttype = Dict{Symbol,Any})
-
-    if haskey(prs, :indets)
-      R, vars = PolynomialRing(ZZ, Vector{String}(prs[:indets]))
-    else
-      R, vars = (ZZ, fmpz[])
-    end
-
-    m = length(prs[:ordinary])
-    n = length(prs[:hc_series])
-    list = prs[:decmat]
-    for i in 1:length(list)
-      if isa(list[i], Vector)
-        cfs = list[i][2:2:end]
-        exp = Vector{Int64}[]
-        for j in 1:2:(length(list[i])-1)
-          monexp = zeros(Int64, length(vars))
-          for k in 1:2:(length(list[i][j])-1)
-            monexp[list[i][j][k]] = list[i][j][k+1]
-          end
-          push!(exp, monexp)
-        end
-        list[i] = R(cfs, exp)
-      end
-    end
-    decmat = matrix(R, m, n, list)
-
-    obj = GenericDecompositionMatrix(
-      prs[:type],
-      prs[:n],
-      prs[:d],
-      prs[:ordinary],
-      prs[:hc_series],
-      [Tuple{String, String, Int}(x) for x in prs[:blocks]],
-      prs[:blocklabels],
-      R,
-      vars,
-      decmat,
-      prs[:condition],
-      prs[:origin],
-    )
-end
-
-zero_repl_string(str::String) = (str == "0" ? "." : str)
-
-function Base.show(io::IO, ::MIME"text/latex", decmat::GenericDecompositionMatrix)
-  print(io, "\$")
-  show(IOContext(io, :TeX => true), "text/plain", decmat)
-  print(io, "\$")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", decmat::GenericDecompositionMatrix)
-    name = decmat.type*string(decmat.n)*", d = "*string(decmat.d)
-
-    # Decide whether we want to restrict the output to one block.
-    if haskey(io, :block)
-      b = io[:block]
-      name = name*" (block $b)"
-      colindices = filter(j -> decmat.blocklabels[j] == b,
-                          1:length(decmat.blocklabels))
-      rowindices = filter(i -> ! iszero(decmat.decmat[i, colindices]),
-                          1:length(decmat.ordinary))
-
-      hc_series = decmat.hc_series[colindices]
-      ordinary = decmat.ordinary[rowindices]
-    else
-      colindices = 1:length(decmat.blocklabels)
-      rowindices = 1:length(decmat.ordinary)
-      hc_series = decmat.hc_series
-      ordinary = decmat.ordinary
-    end
-
-    # Create the IO context.
-    ioc = IOContext(io,
-      :header => [name, ""],
-      :labels_col => hc_series,
-      :separators_row => [0],
-      :separators_col => [0],
-      :labels_row => ordinary,
-    )
-
-    # Create strings from the matrix entries.
-    strmat = [zero_repl_string(string(decmat.decmat[i,j]))
-              for i in rowindices, j in colindices]
-
-    # Print the labelled matrix.
-    labelled_matrix_formatted(ioc, strmat)
-end
 
 """
     generic_decomposition_matrices_overview()
@@ -213,6 +87,23 @@ function generic_decomposition_matrices_overview()
         print( "\n  " );
         i = 0
       end
+    end
+end
+
+function __init__()
+    if isdefined(Main, :Oscar)
+      # If Oscar is available then use its polynomials.
+      Requires.@require Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13" begin
+        include("for_oscar.jl")
+      end
+    elseif isdefined(Main, :Gapjm)
+      # If Gapjm is available then use its polynomials.
+      Requires.@require Gapjm = "367f69f0-ca63-11e8-2372-438b29340c1b" begin
+        include("MatrixDisplay.jl")
+        include("for_gapjm.jl")
+      end
+    else
+      error("need one of Oscar.jl, Gapjm.jl")
     end
 end
 

--- a/src/GenericDecMats.jl
+++ b/src/GenericDecMats.jl
@@ -68,14 +68,100 @@ export generic_decomposition_matrix,
 # The data files are stored in this directory.
 const _datadir = abspath(@__DIR__, "..", "data")
 
+mutable struct GenericDecompositionMatrix
+    # parameters
+    type::String
+    n::Int
+    d::Int
+    # row and column labels
+    ordinary::Vector{String}
+    hc_series::Vector{String}
+    # distribution of rows (ordinary) to blocks
+    blocks::Vector{Tuple{String, String, Int}}
+    blocklabels::Vector{Int}
+    # dec. matrix and its entries (no type information)
+    vars
+    decmat
+    # exclude some values of q if necessary
+    condition::String
+    # bibliographical information
+    origin::String
+end
+
+"""
+    generic_decomposition_matrix(type::String, n::Int, d::Int)
+    generic_decomposition_matrix(name::String)
+
+Return the object described by the inputs if it is available,
+and `nothing` otherwise.
+"""
+function generic_decomposition_matrix(type::String, n::Int, d::Int)
+    return generic_decomposition_matrix(type*string(n)*"d"*string(d))
+end
+
+# load from file if available
+function generic_decomposition_matrix(name::String)
+    filename = _datadir*"/"*name*".json"
+    isfile(filename) || return nothing
+    str = read(filename, String)
+    prs = JSON.parse(str; dicttype = Dict{Symbol,Any})
+
+    # Construct the decomposition matrix.
+    if haskey(prs, :indets)
+      indets = Vector{String}(prs[:indets])
+    else
+      indets = String[]
+    end
+    m = length(prs[:ordinary])
+    n = length(prs[:hc_series])
+    list = prs[:decmat]
+    vars, decmat =_decomposition_matrix_from_list(list, indets, m, n)
+
+    # Extend the 'blocklabels' list by defect zero characters.
+    diff = m - length(prs[:blocklabels])
+    if 0 < diff
+      mx = maximum(prs[:blocklabels])
+      append!(prs[:blocklabels], (mx+1):(mx+diff) )
+    end
+
+    # Extend the 'blocks' list by defect zero blocks if necessary.
+    nam = "$(prs[:type])$(prs[:n])"
+    for i in (length(prs[:blocks])+1):maximum(prs[:blocklabels])
+      push!(prs[:blocks],
+            [nam, prs[:ordinary][findfirst(isequal(i), prs[:blocklabels])], 0])
+    end
+
+    obj = GenericDecompositionMatrix(
+      prs[:type],
+      prs[:n],
+      prs[:d],
+      prs[:ordinary],
+      prs[:hc_series],
+      [Tuple{String, String, Int}(x) for x in prs[:blocks]],
+      prs[:blocklabels],
+      vars,
+      decmat,
+      prs[:condition],
+      prs[:origin],
+    )
+end
+
+"""
+    generic_decomposition_matrices_names()
+
+Return an array of the names of the available matrices.
+"""
+function generic_decomposition_matrices_names()
+    return [x[1:findfirst('.', x)-1] for x in readdir(_datadir)]
+end
+
 """
     generic_decomposition_matrices_overview()
 
 Show an overview of the available generic decomposition matrices.
 """
 function generic_decomposition_matrices_overview()
-    files = readdir(_datadir)
-    names = [x[1:findfirst('.', x)-1] for x in files]
+    names = generic_decomposition_matrices_names()
     mx = maximum(map(length, names)) + 1
     ncol = div(displaysize(stdout)[2] - 4, mx)
     i = 0
@@ -88,6 +174,51 @@ function generic_decomposition_matrices_overview()
         i = 0
       end
     end
+end
+
+function Base.show(io::IO, ::MIME"text/latex", decmat::GenericDecompositionMatrix)
+  print(io, "\$")
+  show(IOContext(io, :TeX => true), "text/plain", decmat)
+  print(io, "\$")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", decmat::GenericDecompositionMatrix)
+    name = decmat.type*string(decmat.n)*", d = "*string(decmat.d)
+
+    # Decide whether we want to restrict the output to one block.
+    if haskey(io, :block)
+      b = io[:block]
+      name = name*" (block $b)"
+      colindices = filter(j -> decmat.blocklabels[j] == b,
+                          1:length(decmat.blocklabels))
+      rowindices = filter(i -> ! iszero(decmat.decmat[i, colindices]),
+                          1:length(decmat.ordinary))
+
+      hc_series = decmat.hc_series[colindices]
+      ordinary = decmat.ordinary[rowindices]
+    else
+      colindices = 1:length(decmat.blocklabels)
+      rowindices = 1:length(decmat.ordinary)
+      hc_series = decmat.hc_series
+      ordinary = decmat.ordinary
+    end
+
+    # Create the IO context.
+    ioc = IOContext(io,
+      :header => [name, ""],
+      :labels_col => hc_series,
+      :separators_row => [0],
+      :separators_col => [0],
+      :labels_row => ordinary,
+      :limit => true,
+    )
+
+    # Create strings from the matrix entries.
+    strmat = [zero_repl_string(decmat.decmat[i,j])
+              for i in rowindices, j in colindices]
+
+    # Print the labelled matrix.
+    _labelled_matrix_formatted(ioc, strmat)
 end
 
 function __init__()
@@ -103,7 +234,8 @@ function __init__()
         include("for_gapjm.jl")
       end
     else
-      error("need one of Oscar.jl, Gapjm.jl")
+      # One of the two packages must be available in advance.
+      error("need either Oscar.jl or Gapjm.jl")
     end
 end
 

--- a/src/MatrixDisplay.jl
+++ b/src/MatrixDisplay.jl
@@ -20,8 +20,6 @@
 ##  Some open items (to be addressed if there is interest):
 ##  Support left/centered/right alignment of columns and of the whole table.
 
-export labelled_matrix_formatted
-
 
 # `lpad` is wrong for example for strings containing overlined characters,
 # such as "A̅".

--- a/src/MatrixDisplay.jl
+++ b/src/MatrixDisplay.jl
@@ -1,0 +1,403 @@
+#############################################################################
+##
+##  Provide functionality for displaying labelled matrices,
+##  that is, two-dimensional arrays of strings
+##  together with row labels, columns labels, header, and footer
+##
+##  Typical examples are character tables of groups,
+##  where the character names and class names appear as row and column labels,
+##  respectively, the name of the table is shown in the header,
+##  and a legend of irrationalities info in the footer.
+##
+##  There is support for the output of \LaTeX format strings
+##  as well as for column aligned text in a Julia session.
+##
+##  The code was inspired by the ideas underlying
+##  [GAP's Browse package](http://www.math.rwth-aachen.de/~Browse/),
+##  and by Jean Michel's implementation of character table display in his
+##  [Julia package Gapjm.jl](https://github.com/jmichel7/Gapjm.jl).
+##
+##  Some open items (to be addressed if there is interest):
+##  Support left/centered/right alignment of columns and of the whole table.
+
+export labelled_matrix_formatted
+
+
+# `lpad` is wrong for example for strings containing overlined characters,
+# such as "A̅".
+# (This had been observed already by Jean Michel.
+# See https://github.com/JuliaLang/julia/pull/39044,
+# a fix seems to become available in Julia 1.7.)
+mylpad(s::String,n::Int) = " "^(n-textwidth(s))*s
+
+
+# for conversions from \LaTeX format to unicode format,
+# deals with subscripts and superscripts in braces `{}`,
+# character values, character names
+const superscript = Dict(zip("-0123456789", "⁻⁰¹²³⁴⁵⁶⁷⁸⁹"))
+const subscript = Dict(zip("-0123456789", "₋₀₁₂₃₄₅₆₇₈₉"))
+
+function replace_TeX(str::String)
+  str = replace(str, "\\chi" => "χ")
+  str = replace(str, "\\phi" => "φ")
+  str = replace(str, "\\varphi" => "φ")
+  str = replace(str, "\\zeta" => "ζ")
+  str = replace(str, r"\^\{[-0123456789]*\}" => (s -> map(x->superscript[x], s[3:end-1])))
+  str = replace(str, r"_\{[-0123456789]*\}" => (s -> map(x->subscript[x], s[3:end-1])))
+  str = replace(str, r"\\overline\{(?<nam>[A-Z]*)\}" => s"\g<nam>\u0305")
+  return str
+end
+
+
+"""
+    function labelled_matrix_formatted(io::IO, mat::Matrix{String})
+
+Write a formatted version of `mat` to `io`.
+The following attributes of `io` are supported.
+
+- `:TeX`:
+  Produce a LaTeX format `array` if the value is `true`,
+  otherwise produce column aligned text format with unicode characters and
+  sub-/superscripts.
+
+- `:subset_row`:
+  array of positions of those rows of `mat` that shall be shown,
+
+- `:subset_col`:
+  array of positions of those columns of `mat` that shall be shown,
+
+- `:header`:
+  array of strings to be shown above `mat`,
+
+- `:corner`:
+  matrix (or vector) of strings to be shown on the left of (and aligned to)
+  the column labels and above (and aligned to) the row labels
+
+- `:labels_row`:
+  matrix (or vector) of strings to be shown on the left of and aligned to
+  the rows of `mat`,
+  (the `i`-th row corresponds to the `i`-th row of `mat`,
+  also if `:subset_row` restricts the shown rows),
+
+- `:labels_col`:
+  matrix (or vector) of strings to be shown above and aligned to
+  the columns of `mat`
+  (the `j`-th column corresponds to the `j`-th column of `mat`,
+  also if `:subset_col` restricts the shown columns),
+
+- `:footer`:
+  array of strings to be shown below `mat`,
+
+- `:separators_row`:
+  array of numbers `i` such that a horizontal line shall be drawn
+  below the `i`-th shown row
+  (enter `0` for a line above the first row),
+
+- `:separators_col`:
+  array of numbers `j` such that a vertical line shall be drawn
+  instead of a blank behind the `j`-th shown column
+  (enter `0` for a line in front of the first column),
+
+- `:portions_row`:
+  array of numbers of rows after which a new labelled table shall be started;
+  the default is to have just one portion.
+
+- `:portions_col`:
+  array of numbers of column after which a new labelled table shall be started;
+  the default is to have just one portion in the `:TeX` case,
+  and to create portions according to the screen width otherwise,
+
+## Examples
+```jldoctest
+julia> m = 3; n = 4;  mat = Array{String}(undef, m, n);
+
+julia> for i in 1:m for j in 1:n mat[i,j] = string( (i,j) ); end; end
+
+julia> mat
+3×4 Matrix{String}:
+ "(1, 1)"  "(1, 2)"  "(1, 3)"  "(1, 4)"
+ "(2, 1)"  "(2, 2)"  "(2, 3)"  "(2, 4)"
+ "(3, 1)"  "(3, 2)"  "(3, 3)"  "(3, 4)"
+
+julia> io = IOBuffer();   # simply using `stdout` does not work in doctests
+
+julia> ioc = IOContext(io,
+              :header => ["", "a labelled matrix", ""],
+              :labels_row => [string(i) for i in 1:m],
+              :labels_col => [string(j) for j in 1:n],
+              :separators_row => [0],
+              :separators_col => [0],
+              :footer => ["", "with footer"],
+             );
+
+julia> labelled_matrix_formatted(ioc, mat)
+
+julia> print(String(take!(io)))
+
+a labelled matrix
+
+ │     1      2      3      4
+─┼───────────────────────────
+1│(1, 1) (1, 2) (1, 3) (1, 4)
+2│(2, 1) (2, 2) (2, 3) (2, 4)
+3│(3, 1) (3, 2) (3, 3) (3, 4)
+
+with footer
+
+julia> ioc = IOContext(io,
+              :labels_row => [string(i) for i in 1:m],
+              :labels_col => [string(j) for j in 1:n],
+              :separators_row => [0],
+              :separators_col => [0],
+              :portions_row => [2,1],
+              :portions_col => [2,2],
+             );
+
+julia> labelled_matrix_formatted(ioc, mat)
+
+julia> print(String(take!(io)))
+ │     1      2
+─┼─────────────
+1│(1, 1) (1, 2)
+2│(2, 1) (2, 2)
+
+ │     1      2
+─┼─────────────
+3│(3, 1) (3, 2)
+
+ │     3      4
+─┼─────────────
+1│(1, 3) (1, 4)
+2│(2, 3) (2, 4)
+
+ │     3      4
+─┼─────────────
+3│(3, 3) (3, 4)
+
+```
+"""
+function labelled_matrix_formatted(io::IO, mat::Matrix{String})
+    TeX = get(io, :TeX, false)
+
+    subset_row = get(io, :subset_row, 1:size(mat, 1))
+    subset_col = get(io, :subset_col, 1:size(mat, 2))
+    m2 = size(subset_row, 1)
+    n2 = size(subset_col, 1)
+
+    # Get the three surrounding matrices.
+    # If some of them were given as vectors then turn them into matrices.
+    labels_col = get(io, :labels_col, fill("", 0, n2))
+    labels_row = get(io, :labels_row, fill("", m2, 0))
+
+    if length(size(labels_row)) == 1
+      # one column of row labels
+      labels_row = reshape(labels_row, length(labels_row), 1)
+    end
+    if length(size(labels_col)) == 1
+      # one row of column labels
+      labels_col = reshape(labels_col, 1, length(labels_col))
+    end
+
+    m1 = size(labels_col, 1)
+    n1 = size(labels_row, 2)
+    corner = get(io, :corner, fill("", m1, n1))
+    if length(size(corner)) == 1
+      # one column of labels above the row labels
+      corner = reshape(corner, length(corner), 1)
+    end
+
+    @assert size(corner, 1) == m1 "row numbers in corner and column labels differ"
+    @assert size(corner, 2) == n1 "column numbers in corner and row labels differ"
+    @assert size(labels_row, 1) == m2 "row numbers in row labels and matrix differ"
+    @assert size(labels_col, 2) == n2 "column numbers in column labels and matrix differ"
+
+    m = m1 + m2
+
+    header = get(io, :header, [])
+    footer = get(io, :footer, [])
+
+    # Concatenate corner part and row labels (restricted to the relevant rows).
+    leftpart = vcat(corner, labels_row[subset_row, 1:size(labels_row, 2)])
+
+    # Concatenate column labels (restricted to the relevant columns)
+    # and `mat` (restricted to the relevant rows and columns).
+    rightpart = vcat(labels_col[1:size(labels_col, 1), subset_col],
+                     mat[subset_row, subset_col])
+
+    if ! TeX
+      # If no `TeX` output is required then
+      # replace markup in the matrices, ...
+      leftpart = map(replace_TeX, leftpart)
+      rightpart = map(replace_TeX, rightpart)
+
+      header = map(replace_TeX, header)
+      footer = map(replace_TeX, footer)
+
+      # ... compute columns widths of the corner entries and row labels ...
+      leftwidth = map(textwidth, leftpart)
+      leftrows = [leftwidth[i,:] for i in 1:m]
+      widths_leftpart = map(max, leftrows...)
+
+      # ... and of the column labels and matrix entries.
+      rightwidth = map(textwidth, rightpart)
+      rightrows = [rightwidth[i,:] for i in 1:m]
+      widths_rightpart = map(max, rightrows...)
+
+      # Compute the width of the row labels part.
+      leftwidthsum = sum(widths_leftpart) + length(widths_leftpart) - 1
+      if leftwidthsum == -1
+        leftwidthsum = 0
+      end
+    end
+
+    # Print the header (a vector of strings).
+    for line in header
+      write(io, line, "\n")
+    end
+
+    separators_col = get(io, :separators_col, [])
+    separators_row = map(x -> x+m1, get(io, :separators_row, []))
+
+    # Determine the column portions.
+    portions_col = get(io, :portions_col, [])
+    if portions_col == []
+      # Set a default.
+      if TeX
+        # Do not split into column portions.
+        portions_col = [n2]
+      else
+        # Distribute the matrix into column portions,
+        # according to the screen width.
+        screen_width = displaysize(io)[2]
+        if leftwidthsum >= screen_width
+          write(io, "(row label part is too wide for the screen)\n")
+          return
+        end
+
+        num = 0
+        width = leftwidthsum
+        for w in widths_rightpart
+          width = width + w + 1
+          if width >= screen_width
+            if num == 0
+              # This column will be too wide
+              # but we have to take at least one.
+              push!(portions_col, 1)
+              width = leftwidthsum
+            else
+              push!(portions_col, num)
+              num = 1
+              width = leftwidthsum + w + 1
+            end
+          else
+            num = num+1
+          end
+        end
+        if num != 0
+          push!(portions_col, num)
+        end
+      end
+    end
+
+    # We do not distribute the table into row portions
+    # if this is not wanted.
+    portions_row = get(io, :portions_row, [m2])
+
+    # Run over the column portions.
+    cpos = 0
+    for ci in 1:length(portions_col)
+      cnum = portions_col[ci]
+      crange = (cpos + 1):(cpos + cnum)
+      cpos = cpos + cnum
+
+      if TeX
+        cpattern = 0 in separators_col ? "|" : ""
+        for j in crange
+          cpattern = cpattern * (j in separators_col ? "r|" : "r")
+        end
+      else
+        if 0 in separators_col
+          cprefix = "\u2502"
+        elseif n1 == 0
+          cprefix = ""
+        else
+          cprefix = " "
+        end
+        cpattern = String[]
+        for j in crange
+          push!(cpattern, j in separators_col ? "\u2502" : " ")
+        end
+        if ! (crange[end] in separators_col)
+          cpattern[end] = ""
+        end
+      end
+
+      # For each column portion, run over the row portions.
+      rpos = 0
+      for ri in 1:length(portions_row)
+        rnum = portions_row[ri]
+        # Print first the column labels and then the row portion.
+        rrange = vcat(1:m1, (rpos + m1 + 1):(rpos + m1 + rnum))
+        rpos = rpos + rnum
+        if TeX
+          write(io, "\\begin{array}{" * repeat("r", n1) * cpattern * "}", "\n")
+        end
+
+        # Compute the horizontal separator line.
+        if TeX
+          hline = "\\hline"
+        else
+          hline = repeat("\u2500", leftwidthsum)
+          if 0 in separators_col
+            hline = hline * "\u253C"
+          elseif n1 != 0
+            hline = hline * "\u2500"
+          end
+          for jj in 1:length(crange)
+            j = crange[jj]
+            hline = hline * repeat("\u2500", widths_rightpart[j])
+            if jj < length(crange) || j in separators_col
+              if j in separators_col
+                hline = hline * "\u253C"
+              else
+                hline = hline * "\u2500"
+              end
+            end
+          end
+        end
+
+        # Print the matrices.
+        for i in rrange
+          if 0 in separators_row && ri == 1 && m1 == 0 && i == rrange[1]
+            write(io, hline, "\n")
+          end
+          if TeX
+            write(io, join(leftpart[i,:], " & "))
+            if n1 > 0
+              write(io, " & ")
+            end
+            write(io, join(rightpart[i,:][crange], " & "), " \\\\\n")
+          else
+            write(io, join(map(mylpad, leftpart[i,:], widths_leftpart), " "),
+                      cprefix,
+                      join(join.(collect(zip(map(mylpad, rightpart[i,:][crange], widths_rightpart[crange]), cpattern)))), "\n")
+          end
+          if i in separators_row
+            write(io, hline, "\n")
+          end
+        end
+        if TeX
+          write(io, "\\end{array}\n")
+        end
+        if ci != length(portions_col) || ri != length(portions_row)
+          write(io, "\n")
+        end
+      end
+    end
+
+    # footer (vector of strings)
+    for line in footer
+      write(io, line, "\n")
+    end
+end
+

--- a/src/for_gapjm.jl
+++ b/src/for_gapjm.jl
@@ -1,0 +1,144 @@
+mutable struct GenericDecompositionMatrix
+    # parameters
+    type::String
+    n::Int
+    d::Int
+    # row and column labels
+    ordinary::Vector{String}
+    hc_series::Vector{String}
+    # distribution of rows (ordinary) to blocks
+    blocks::Vector{Tuple{String, String, Int}}
+    blocklabels::Vector{Int}
+    # dec. matrix and its entries
+    vars::Vector{Gapjm.Mvp}
+    decmat::Matrix{Gapjm.Mvp}
+    # exclude some values of q if necessary
+    condition::String
+    # bibliographical information
+    origin::String
+end
+
+"""
+    generic_decomposition_matrix(type::String, n::Int, d::Int)
+    generic_decomposition_matrix(name::String)
+
+Return the object described by the inputs if it is available,
+and `nothing` otherwise.
+"""
+function generic_decomposition_matrix(type::String, n::Int, d::Int)
+    return generic_decomposition_matrix(type*string(n)*"d"*string(d))
+end
+
+# load from file if available
+function generic_decomposition_matrix(name::String)
+    filename = _datadir*"/"*name*".json"
+    isfile(filename) || return nothing
+    str = read(filename, String)
+    prs = JSON.parse(str; dicttype = Dict{Symbol,Any})
+
+    if haskey(prs, :indets)
+      vars = [Gapjm.Mvp(Symbol(x)) for x in prs[:indets]]
+    else
+      vars = Gapjm.Mvp[]
+    end
+
+    m = length(prs[:ordinary])
+    n = length(prs[:hc_series])
+    list = prs[:decmat]
+    for i in 1:length(list)
+      if isa(list[i], Vector)
+        val = 0
+        l = list[i]
+        for j in 1:2:(length(l)-1)
+          mon = 1
+          for k in 1:2:length(l[j])
+            mon = mon*vars[l[j][k]]^l[j][k+1]
+          end
+          val = val + l[j+1]*mon
+        end
+        list[i] = val
+      end
+    end
+    decmat = Matrix{Gapjm.Mvp}(reshape(list, (m, n))')
+
+    # Extend the 'blocklabels' list by defect zero characters.
+    diff = m - length(prs[:blocklabels])
+    if 0 < diff
+      mx = maximum(prs[:blocklabels])
+      append!(prs[:blocklabels], (mx+1):(mx+diff) )
+    end
+
+    # Extend the 'blocks' list by defect zero blocks if necessary.
+    nam = "$(prs[:type])$(prs[:n])"
+    for i in (length(prs[:blocks])+1):maximum(prs[:blocklabels])
+      push!(prs[:blocks],
+            [nam, prs[:ordinary][findfirst(isequal(i), prs[:blocklabels])], 0])
+    end
+
+    obj = GenericDecompositionMatrix(
+      prs[:type],
+      prs[:n],
+      prs[:d],
+      prs[:ordinary],
+      prs[:hc_series],
+      [Tuple{String, String, Int}(x) for x in prs[:blocks]],
+      prs[:blocklabels],
+      vars,
+      decmat,
+      prs[:condition],
+      prs[:origin],
+    )
+end
+
+function zero_repl_string(pol::Gapjm.Mvp)
+    io = IOBuffer()
+    ioc = IOContext(io, :limit => true)
+    show(ioc, pol)
+    str = String(take!(io))
+    return (str == "0" ? "." : str)
+end
+
+function Base.show(io::IO, ::MIME"text/latex", decmat::GenericDecompositionMatrix)
+  print(io, "\$")
+  show(IOContext(io, :TeX => true), "text/plain", decmat)
+  print(io, "\$")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", decmat::GenericDecompositionMatrix)
+    name = decmat.type*string(decmat.n)*", d = "*string(decmat.d)
+
+    # Decide whether we want to restrict the output to one block.
+    if haskey(io, :block)
+      b = io[:block]
+      name = name*" (block $b)"
+      colindices = filter(j -> decmat.blocklabels[j] == b,
+                          1:length(decmat.blocklabels))
+      rowindices = filter(i -> ! iszero(decmat.decmat[i, colindices]),
+                          1:length(decmat.ordinary))
+
+      hc_series = decmat.hc_series[colindices]
+      ordinary = decmat.ordinary[rowindices]
+    else
+      colindices = 1:length(decmat.blocklabels)
+      rowindices = 1:length(decmat.ordinary)
+      hc_series = decmat.hc_series
+      ordinary = decmat.ordinary
+    end
+
+    # Create the IO context.
+    ioc = IOContext(io,
+      :header => [name, ""],
+      :labels_col => hc_series,
+      :separators_row => [0],
+      :separators_col => [0],
+      :labels_row => ordinary,
+      :limit => true,
+    )
+
+    # Create strings from the matrix entries.
+    strmat = [zero_repl_string(decmat.decmat[i,j])
+              for i in rowindices, j in colindices]
+
+    # Print the labelled matrix.
+    labelled_matrix_formatted(ioc, strmat)
+end

--- a/src/for_gapjm.jl
+++ b/src/for_gapjm.jl
@@ -1,50 +1,13 @@
-mutable struct GenericDecompositionMatrix
-    # parameters
-    type::String
-    n::Int
-    d::Int
-    # row and column labels
-    ordinary::Vector{String}
-    hc_series::Vector{String}
-    # distribution of rows (ordinary) to blocks
-    blocks::Vector{Tuple{String, String, Int}}
-    blocklabels::Vector{Int}
-    # dec. matrix and its entries
-    vars::Vector{Gapjm.Mvp}
-    decmat::Matrix{Gapjm.Mvp}
-    # exclude some values of q if necessary
-    condition::String
-    # bibliographical information
-    origin::String
-end
-
-"""
-    generic_decomposition_matrix(type::String, n::Int, d::Int)
-    generic_decomposition_matrix(name::String)
-
-Return the object described by the inputs if it is available,
-and `nothing` otherwise.
-"""
-function generic_decomposition_matrix(type::String, n::Int, d::Int)
-    return generic_decomposition_matrix(type*string(n)*"d"*string(d))
-end
-
-# load from file if available
-function generic_decomposition_matrix(name::String)
-    filename = _datadir*"/"*name*".json"
-    isfile(filename) || return nothing
-    str = read(filename, String)
-    prs = JSON.parse(str; dicttype = Dict{Symbol,Any})
-
-    if haskey(prs, :indets)
-      vars = [Gapjm.Mvp(Symbol(x)) for x in prs[:indets]]
+# turn the list of integers and vectors into the decomposition matrix
+# in the Gapjm context
+function _decomposition_matrix_from_list(list::Vector, indets::Vector{String}, m::Int, n::Int)
+    if length(indets) > 0
+      vars = [Gapjm.Mvp(Symbol(x)) for x in indets]
     else
-      vars = Gapjm.Mvp[]
+      vars = Gapjm.Mvp{Int, Int}[]
     end
 
-    m = length(prs[:ordinary])
-    n = length(prs[:hc_series])
-    list = prs[:decmat]
+    # Construct the decomposition matrix.
     for i in 1:length(list)
       if isa(list[i], Vector)
         val = 0
@@ -59,36 +22,13 @@ function generic_decomposition_matrix(name::String)
         list[i] = val
       end
     end
-    decmat = Matrix{Gapjm.Mvp}(reshape(list, (m, n))')
-
-    # Extend the 'blocklabels' list by defect zero characters.
-    diff = m - length(prs[:blocklabels])
-    if 0 < diff
-      mx = maximum(prs[:blocklabels])
-      append!(prs[:blocklabels], (mx+1):(mx+diff) )
-    end
-
-    # Extend the 'blocks' list by defect zero blocks if necessary.
-    nam = "$(prs[:type])$(prs[:n])"
-    for i in (length(prs[:blocks])+1):maximum(prs[:blocklabels])
-      push!(prs[:blocks],
-            [nam, prs[:ordinary][findfirst(isequal(i), prs[:blocklabels])], 0])
-    end
-
-    obj = GenericDecompositionMatrix(
-      prs[:type],
-      prs[:n],
-      prs[:d],
-      prs[:ordinary],
-      prs[:hc_series],
-      [Tuple{String, String, Int}(x) for x in prs[:blocks]],
-      prs[:blocklabels],
-      vars,
-      decmat,
-      prs[:condition],
-      prs[:origin],
-    )
+    list = Gapjm.Mvp{Int,Int}.(list)
+  # decmat = Matrix{Gapjm.Mvp}(reshape(list, (m, n))')
+  # decmat = Gapjm.Mvp{Int,Int}.(reshape(list, (m, n))')
+    return vars, reshape(list, (m, n))'
 end
+
+_labelled_matrix_formatted = labelled_matrix_formatted
 
 function zero_repl_string(pol::Gapjm.Mvp)
     io = IOBuffer()
@@ -96,49 +36,4 @@ function zero_repl_string(pol::Gapjm.Mvp)
     show(ioc, pol)
     str = String(take!(io))
     return (str == "0" ? "." : str)
-end
-
-function Base.show(io::IO, ::MIME"text/latex", decmat::GenericDecompositionMatrix)
-  print(io, "\$")
-  show(IOContext(io, :TeX => true), "text/plain", decmat)
-  print(io, "\$")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", decmat::GenericDecompositionMatrix)
-    name = decmat.type*string(decmat.n)*", d = "*string(decmat.d)
-
-    # Decide whether we want to restrict the output to one block.
-    if haskey(io, :block)
-      b = io[:block]
-      name = name*" (block $b)"
-      colindices = filter(j -> decmat.blocklabels[j] == b,
-                          1:length(decmat.blocklabels))
-      rowindices = filter(i -> ! iszero(decmat.decmat[i, colindices]),
-                          1:length(decmat.ordinary))
-
-      hc_series = decmat.hc_series[colindices]
-      ordinary = decmat.ordinary[rowindices]
-    else
-      colindices = 1:length(decmat.blocklabels)
-      rowindices = 1:length(decmat.ordinary)
-      hc_series = decmat.hc_series
-      ordinary = decmat.ordinary
-    end
-
-    # Create the IO context.
-    ioc = IOContext(io,
-      :header => [name, ""],
-      :labels_col => hc_series,
-      :separators_row => [0],
-      :separators_col => [0],
-      :labels_row => ordinary,
-      :limit => true,
-    )
-
-    # Create strings from the matrix entries.
-    strmat = [zero_repl_string(decmat.decmat[i,j])
-              for i in rowindices, j in colindices]
-
-    # Print the labelled matrix.
-    labelled_matrix_formatted(ioc, strmat)
 end

--- a/src/for_oscar.jl
+++ b/src/for_oscar.jl
@@ -1,0 +1,140 @@
+mutable struct GenericDecompositionMatrix
+    # parameters
+    type::String
+    n::Int
+    d::Int
+    # row and column labels
+    ordinary::Vector{String}
+    hc_series::Vector{String}
+    # distribution of rows (ordinary) to blocks
+    blocks::Vector{Tuple{String, String, Int}}
+    blocklabels::Vector{Int}
+    # dec. matrix and its entries
+    R::Union{Oscar.MPolyRing{Oscar.fmpz}, Oscar.FlintIntegerRing}
+    vars::Union{Vector{Oscar.fmpz_mpoly}, Vector{Oscar.fmpz}}
+    decmat::Union{Oscar.Generic.MatSpaceElem{Oscar.fmpz_mpoly},Oscar.fmpz_mat}
+    # exclude some values of q if necessary
+    condition::String
+    # bibliographical information
+    origin::String
+end
+
+"""
+    generic_decomposition_matrix(type::String, n::Int, d::Int)
+    generic_decomposition_matrix(name::String)
+
+Return the object described by the inputs if it is available,
+and `nothing` otherwise.
+"""
+function generic_decomposition_matrix(type::String, n::Int, d::Int)
+    return generic_decomposition_matrix(type*string(n)*"d"*string(d))
+end
+
+# load from file if available
+function generic_decomposition_matrix(name::String)
+    filename = _datadir*"/"*name*".json"
+    isfile(filename) || return nothing
+    str = read(filename, String)
+    prs = JSON.parse(str; dicttype = Dict{Symbol,Any})
+
+    if haskey(prs, :indets)
+      R, vars = Oscar.PolynomialRing(Oscar.ZZ, Vector{String}(prs[:indets]))
+    else
+      R, vars = (Oscar.ZZ, Oscar.fmpz[])
+    end
+
+    # Construct the decomposition matrix.
+    m = length(prs[:ordinary])
+    n = length(prs[:hc_series])
+    list = prs[:decmat]
+    for i in 1:length(list)
+      if isa(list[i], Vector)
+        cfs = list[i][2:2:end]
+        exp = Vector{Int64}[]
+        for j in 1:2:(length(list[i])-1)
+          monexp = zeros(Int64, length(vars))
+          for k in 1:2:(length(list[i][j])-1)
+            monexp[list[i][j][k]] = list[i][j][k+1]
+          end
+          push!(exp, monexp)
+        end
+        list[i] = R(cfs, exp)
+      end
+    end
+    decmat = Oscar.matrix(R, m, n, list)
+
+    # Extend the 'blocklabels' list by defect zero characters.
+    diff = m - length(prs[:blocklabels])
+    if 0 < diff
+      mx = maximum(prs[:blocklabels])
+      append!(prs[:blocklabels], (mx+1):(mx+diff) )
+    end
+
+    # Extend the 'blocks' list by defect zero blocks if necessary.
+    nam = "$(prs[:type])$(prs[:n])"
+    for i in (length(prs[:blocks])+1):maximum(prs[:blocklabels])
+      push!(prs[:blocks],
+            [nam, prs[:ordinary][findfirst(isequal(i), prs[:blocklabels])], 0])
+    end
+
+    obj = GenericDecompositionMatrix(
+      prs[:type],
+      prs[:n],
+      prs[:d],
+      prs[:ordinary],
+      prs[:hc_series],
+      [Tuple{String, String, Int}(x) for x in prs[:blocks]],
+      prs[:blocklabels],
+      R,
+      vars,
+      decmat,
+      prs[:condition],
+      prs[:origin],
+    )
+end
+
+zero_repl_string(str::String) = (str == "0" ? "." : str)
+
+function Base.show(io::IO, ::MIME"text/latex", decmat::GenericDecompositionMatrix)
+  print(io, "\$")
+  show(IOContext(io, :TeX => true), "text/plain", decmat)
+  print(io, "\$")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", decmat::GenericDecompositionMatrix)
+    name = decmat.type*string(decmat.n)*", d = "*string(decmat.d)
+
+    # Decide whether we want to restrict the output to one block.
+    if haskey(io, :block)
+      b = io[:block]
+      name = name*" (block $b)"
+      colindices = filter(j -> decmat.blocklabels[j] == b,
+                          1:length(decmat.blocklabels))
+      rowindices = filter(i -> ! iszero(decmat.decmat[i, colindices]),
+                          1:length(decmat.ordinary))
+
+      hc_series = decmat.hc_series[colindices]
+      ordinary = decmat.ordinary[rowindices]
+    else
+      colindices = 1:length(decmat.blocklabels)
+      rowindices = 1:length(decmat.ordinary)
+      hc_series = decmat.hc_series
+      ordinary = decmat.ordinary
+    end
+
+    # Create the IO context.
+    ioc = IOContext(io,
+      :header => [name, ""],
+      :labels_col => hc_series,
+      :separators_row => [0],
+      :separators_col => [0],
+      :labels_row => ordinary,
+    )
+
+    # Create strings from the matrix entries.
+    strmat = [zero_repl_string(string(decmat.decmat[i,j]))
+              for i in rowindices, j in colindices]
+
+    # Print the labelled matrix.
+    Oscar.labelled_matrix_formatted(ioc, strmat)
+end

--- a/src/for_oscar.jl
+++ b/src/for_oscar.jl
@@ -1,52 +1,13 @@
-mutable struct GenericDecompositionMatrix
-    # parameters
-    type::String
-    n::Int
-    d::Int
-    # row and column labels
-    ordinary::Vector{String}
-    hc_series::Vector{String}
-    # distribution of rows (ordinary) to blocks
-    blocks::Vector{Tuple{String, String, Int}}
-    blocklabels::Vector{Int}
-    # dec. matrix and its entries
-    R::Union{Oscar.MPolyRing{Oscar.fmpz}, Oscar.FlintIntegerRing}
-    vars::Union{Vector{Oscar.fmpz_mpoly}, Vector{Oscar.fmpz}}
-    decmat::Union{Oscar.Generic.MatSpaceElem{Oscar.fmpz_mpoly},Oscar.fmpz_mat}
-    # exclude some values of q if necessary
-    condition::String
-    # bibliographical information
-    origin::String
-end
-
-"""
-    generic_decomposition_matrix(type::String, n::Int, d::Int)
-    generic_decomposition_matrix(name::String)
-
-Return the object described by the inputs if it is available,
-and `nothing` otherwise.
-"""
-function generic_decomposition_matrix(type::String, n::Int, d::Int)
-    return generic_decomposition_matrix(type*string(n)*"d"*string(d))
-end
-
-# load from file if available
-function generic_decomposition_matrix(name::String)
-    filename = _datadir*"/"*name*".json"
-    isfile(filename) || return nothing
-    str = read(filename, String)
-    prs = JSON.parse(str; dicttype = Dict{Symbol,Any})
-
-    if haskey(prs, :indets)
-      R, vars = Oscar.PolynomialRing(Oscar.ZZ, Vector{String}(prs[:indets]))
+# turn the list of integers and vectors into the decomposition matrix
+# in the Oscar context
+function _decomposition_matrix_from_list(list::Vector, indets::Vector{String}, m::Int, n::Int)
+    if length(indets) > 0
+      R, vars = Oscar.PolynomialRing(Oscar.ZZ, indets)
     else
       R, vars = (Oscar.ZZ, Oscar.fmpz[])
     end
 
     # Construct the decomposition matrix.
-    m = length(prs[:ordinary])
-    n = length(prs[:hc_series])
-    list = prs[:decmat]
     for i in 1:length(list)
       if isa(list[i], Vector)
         cfs = list[i][2:2:end]
@@ -61,80 +22,13 @@ function generic_decomposition_matrix(name::String)
         list[i] = R(cfs, exp)
       end
     end
-    decmat = Oscar.matrix(R, m, n, list)
 
-    # Extend the 'blocklabels' list by defect zero characters.
-    diff = m - length(prs[:blocklabels])
-    if 0 < diff
-      mx = maximum(prs[:blocklabels])
-      append!(prs[:blocklabels], (mx+1):(mx+diff) )
-    end
-
-    # Extend the 'blocks' list by defect zero blocks if necessary.
-    nam = "$(prs[:type])$(prs[:n])"
-    for i in (length(prs[:blocks])+1):maximum(prs[:blocklabels])
-      push!(prs[:blocks],
-            [nam, prs[:ordinary][findfirst(isequal(i), prs[:blocklabels])], 0])
-    end
-
-    obj = GenericDecompositionMatrix(
-      prs[:type],
-      prs[:n],
-      prs[:d],
-      prs[:ordinary],
-      prs[:hc_series],
-      [Tuple{String, String, Int}(x) for x in prs[:blocks]],
-      prs[:blocklabels],
-      R,
-      vars,
-      decmat,
-      prs[:condition],
-      prs[:origin],
-    )
+    return vars, Oscar.matrix(R, m, n, list)
 end
 
-zero_repl_string(str::String) = (str == "0" ? "." : str)
+_labelled_matrix_formatted = Oscar.labelled_matrix_formatted
 
-function Base.show(io::IO, ::MIME"text/latex", decmat::GenericDecompositionMatrix)
-  print(io, "\$")
-  show(IOContext(io, :TeX => true), "text/plain", decmat)
-  print(io, "\$")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", decmat::GenericDecompositionMatrix)
-    name = decmat.type*string(decmat.n)*", d = "*string(decmat.d)
-
-    # Decide whether we want to restrict the output to one block.
-    if haskey(io, :block)
-      b = io[:block]
-      name = name*" (block $b)"
-      colindices = filter(j -> decmat.blocklabels[j] == b,
-                          1:length(decmat.blocklabels))
-      rowindices = filter(i -> ! iszero(decmat.decmat[i, colindices]),
-                          1:length(decmat.ordinary))
-
-      hc_series = decmat.hc_series[colindices]
-      ordinary = decmat.ordinary[rowindices]
-    else
-      colindices = 1:length(decmat.blocklabels)
-      rowindices = 1:length(decmat.ordinary)
-      hc_series = decmat.hc_series
-      ordinary = decmat.ordinary
-    end
-
-    # Create the IO context.
-    ioc = IOContext(io,
-      :header => [name, ""],
-      :labels_col => hc_series,
-      :separators_row => [0],
-      :separators_col => [0],
-      :labels_row => ordinary,
-    )
-
-    # Create strings from the matrix entries.
-    strmat = [zero_repl_string(string(decmat.decmat[i,j]))
-              for i in rowindices, j in colindices]
-
-    # Print the labelled matrix.
-    Oscar.labelled_matrix_formatted(ioc, strmat)
+function zero_repl_string(obj)
+   str = string(obj)
+   return (str == "0" ? "." : str)
 end


### PR DESCRIPTION
This is a version which can be used either with Oscar.jl or with Gapjm.jl.
The idea is to use Oscar.jl's polynomials if this package is already loaded
before GenericDecMats.jl, and to use Gapjm.jl's multivariate polynomials
if this package is already loaded.

(For technical reasons, Requires.jl is used.
However, we cannot use its feature that the functionality depending on
one of the two packages becomes available as soon as Oscar.jl or Gapjm.jl
gets loaded later on.
Note that the type `GenericDecompositionMatrix` can support only one
of the two types of polynomials.)