### PR TITLE
adjust to the name change Gapjm.jl -> Chevie.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,14 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.6'
-          - '1.7'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest
         include:
           - os: macOS-latest
-            julia-version: '1.6'
+            julia-version: '1.9'
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This repository gives access to the generic decomposition matrices of various gr
 
 Currently the following use cases are supported.
 
-- The [Gapjm.jl](https://github.com/jmichel7/Gapjm.jl) package provides functionality for generic decomposition matrices.
+- The [Chevie.jl](https://github.com/jmichel7/Chevie.jl) package provides functionality for generic decomposition matrices.
 
 - The generic decomposition matrices can be read into [Oscar.jl](https://github.com/oscar-system/Oscar.jl), its matrices and polynomials are used then.
 
 - There is also a [GAP 4](https://www.gap-system.org/) interface, read `init.g` into a GAP session in order to provide functions for loading, displaying, and testing the matrices.
 
-The interfaces to Gapjm.jl and Oscar.jl can be used in the same Julia session.
+The interfaces to Chevie.jl and Oscar.jl can be used in the same Julia session.
 
 There is [a preliminary printout version of the data](https://www.math.rwth-aachen.de/~Thomas.Breuer/GenericDecMats); both the location and the format will be changed.
 

--- a/src/GenericDecMats.jl
+++ b/src/GenericDecMats.jl
@@ -80,7 +80,7 @@ const _datadir = abspath(@__DIR__, "..", "data")
 const _decomposition_matrix_from_list = Dict{Symbol, Function}()
 
 mutable struct GenericDecompositionMatrix
-    # store whether the contents belongs to Oscar or Gapjm
+    # store whether the contents belongs to Oscar or Chevie
     context::Symbol
     # parameters
     type::String
@@ -187,7 +187,7 @@ end
 # support the one argument version only if the method is unique
 function generic_decomposition_matrix(name::String)
     len = length(_decomposition_matrix_from_list)
-    len == 0 && error("no method available, try to load Gapjm.jl or Oscar.jl")
+    len == 0 && error("no method available, try to load Chevie.jl or Oscar.jl")
     len == 1 ||
       error("please specify one of $(string(keys(_decomposition_matrix_from_list))) as second argument")
 
@@ -342,10 +342,10 @@ function __init__()
     Requires.@require Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13" begin
       include("for_oscar.jl")
     end
-    # If Gapjm is available then support a method for its polynomials.
-    Requires.@require Gapjm = "367f69f0-ca63-11e8-2372-438b29340c1b" begin
+    # If Chevie is available then support a method for its polynomials.
+    Requires.@require Chevie = "367f69f0-ca63-11e8-2372-438b29340c1b" begin
       include("MatrixDisplay.jl")
-      include("for_gapjm.jl")
+      include("for_chevie.jl")
     end
 end
 

--- a/src/MatrixDisplay.jl
+++ b/src/MatrixDisplay.jl
@@ -15,7 +15,7 @@
 ##  The code was inspired by the ideas underlying
 ##  [GAP's Browse package](http://www.math.rwth-aachen.de/~Browse/),
 ##  and by Jean Michel's implementation of character table display in his
-##  [Julia package Gapjm.jl](https://github.com/jmichel7/Gapjm.jl).
+##  [Julia package Chevie.jl](https://github.com/jmichel7/Chevie.jl).
 ##
 ##  Some open items (to be addressed if there is interest):
 ##  Support left/centered/right alignment of columns and of the whole table.

--- a/src/for_chevie.jl
+++ b/src/for_chevie.jl
@@ -1,10 +1,10 @@
 # turn the list of integers and vectors into the decomposition matrix
-# in the Gapjm context
-function _decomposition_matrix_from_list_Gapjm(list::Vector, indets::Vector{String}, m::Int, n::Int)
+# in the Chevie context
+function _decomposition_matrix_from_list_Chevie(list::Vector, indets::Vector{String}, m::Int, n::Int)
     if length(indets) > 0
-      vars = [Gapjm.Mvp(Symbol(x)) for x in indets]
+      vars = [Chevie.Mvp(Symbol(x)) for x in indets]
     else
-      vars = Gapjm.Mvp{Int, Int}[]
+      vars = Chevie.Mvp{Int, Int}[]
     end
 
     # Construct the decomposition matrix.
@@ -22,17 +22,17 @@ function _decomposition_matrix_from_list_Gapjm(list::Vector, indets::Vector{Stri
         list[i] = val
       end
     end
-    list = Gapjm.Mvp{Int,Int}.(list)
-  # decmat = Matrix{Gapjm.Mvp}(reshape(list, (m, n))')
-  # decmat = Gapjm.Mvp{Int,Int}.(reshape(list, (m, n))')
+    list = Chevie.Mvp{Int,Int}.(list)
+  # decmat = Matrix{Chevie.Mvp}(reshape(list, (m, n))')
+  # decmat = Chevie.Mvp{Int,Int}.(reshape(list, (m, n))')
     return vars, reshape(list, (m, n))'
 end
 
-_decomposition_matrix_from_list[:Gapjm] = _decomposition_matrix_from_list_Gapjm
+_decomposition_matrix_from_list[:Chevie] = _decomposition_matrix_from_list_Chevie
 
 _labelled_matrix_formatted = labelled_matrix_formatted
 
-function zero_repl_string(pol::Gapjm.Mvp)
+function zero_repl_string(pol::Chevie.Mvp)
     io = IOBuffer()
     ioc = IOContext(io, :limit => true)
     show(ioc, pol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,24 +3,24 @@ using GenericDecMats
 using Pkg
 
 # Try to achieve that there is something to be tested.
-if !(isdefined(Main, :Oscar) || isdefined(Main, :Gapjm))
-  # Try to load `Gapjm`, and try to install it if it is not yet installed.
-  if ! isdefined(Main, :Gapjm)
-    try import Gapjm; catch(e) end
-    if ! isdefined(Main, :Gapjm)
-      Pkg.add(url="https://github.com/jmichel7/Gapjm.jl")
-      try import Gapjm; catch(e) end
+if !(isdefined(Main, :Oscar) || isdefined(Main, :Chevie))
+  # Try to load `Chevie`, and try to install it if it is not yet installed.
+  if ! isdefined(Main, :Chevie)
+    try import Chevie; catch(e) end
+    if ! isdefined(Main, :Chevie)
+      Pkg.add(url="https://github.com/jmichel7/Chevie.jl")
+      try import Chevie; catch(e) end
     end
   end
   # Try to load Oscar.
-  if ! isdefined(Main, :Gapjm)
+  if ! isdefined(Main, :Chevie)
     try import Oscar; catch(e) end
   end
 end
 
-if isdefined(Main, :Oscar) || isdefined(Main, :Gapjm)
+if isdefined(Main, :Oscar) || isdefined(Main, :Chevie)
   include("testdisp.jl")
 end
-if isdefined(Main, :Gapjm)
+if isdefined(Main, :Chevie)
   include("testcons.jl")
 end

--- a/test/testcons.jl
+++ b/test/testcons.jl
@@ -1,4 +1,4 @@
-@testset "check that all matrices can be processed by Gapjm.jl" begin
+@testset "check that all matrices can be processed by Chevie.jl" begin
 
   @testset for nam in GenericDecMats.generic_decomposition_matrices_names()
 
@@ -49,21 +49,21 @@
     d = parse(Int, nam[(pos+1):end])
     if shift isa Function
       n = parse(Int, nam[from:(pos-1)])
-      R = Gapjm.rootdatum(rnam, shift(n))
+      R = Chevie.rootdatum(rnam, shift(n))
     else
-      R = Gapjm.rootdatum(rnam)
+      R = Chevie.rootdatum(rnam)
     end
 
     # The dimension of the matrix must fit.
-    l1 = length(Gapjm.charnames(Gapjm.UnipotentCharacters(R), TeX = true))
+    l1 = length(Chevie.charnames(Chevie.UnipotentCharacters(R), TeX = true))
     obj = GenericDecMats.generic_decomposition_matrix(nam)
     l2 = length(obj.ordinary)
     if l1 != l2 && obj.is_complete == true
       error("$nam: ordinary has length $l2 (should be $l1)")
     end
 
-    # Let Gapjm interpret the matrix.
-    @test Gapjm.generic_decomposition_matrix(R, d) != nothing
+    # Let Chevie interpret the matrix.
+    @test Chevie.generic_decomposition_matrix(R, d) != nothing
   end
 
 end


### PR DESCRIPTION
Since Chevie.jl requires Julia 1.9, it does not make sense to run the CI tests with earlier Julia versions.
Thus the CI tests are now run with Julia 1.9.
(One can still use GenericDecMats.jl together with Oscar.jl in Julia at least 1.6.)