### PR TITLE
adjust version of dependency JSON

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,17 +31,17 @@ jobs:
             julia-version: '1.11'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # For Codecov, we must also fetch the parent of the HEAD commit to
           # be able to properly deal with PRs / merges
           fetch-depth: 2
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.julia-version }}
       - name: Cache artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
@@ -59,4 +59,4 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.9'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest
         include:
           - os: macOS-latest
-            julia-version: '1.9'
+            julia-version: '1.10'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.10'
+          - '1.11'
           - 'nightly'
         os:
           - ubuntu-latest
         include:
           - os: macOS-latest
-            julia-version: '1.10'
+            julia-version: '1.11'
 
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenericDecMats"
 uuid = "a98d1166-8d3f-4eaf-b2a4-26e52ad22d9c"
 authors = ["ThomasBreuer <sam@math.rwth-aachen.de>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -10,7 +10,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-JSON = "0.21"
+JSON = "1.6"
 Requires = "1.2"
 julia = "1.6"
 

--- a/src/for_oscar.jl
+++ b/src/for_oscar.jl
@@ -2,9 +2,9 @@
 # in the Oscar context
 function _decomposition_matrix_from_list_Oscar(list::Vector, indets::Vector{String}, m::Int, n::Int)
     if length(indets) > 0
-      R, vars = Oscar.PolynomialRing(Oscar.ZZ, indets)
+      R, vars = Oscar.polynomial_ring(Oscar.ZZ, indets)
     else
-      R, vars = (Oscar.ZZ, Oscar.fmpz[])
+      R, vars = (Oscar.ZZ, Oscar.ZZRingElem[])
     end
 
     # Construct the decomposition matrix.
@@ -40,8 +40,8 @@ end
 
 function load_references()
   file = joinpath(@__DIR__, "..", "doc", "References.bib.xml")
-  prs = Oscar.GAP.Globals.ParseBibXMLextFiles(Oscar.GAP.julia_to_gap(file))::Oscar.GAP.GapObj
-  txt = Oscar.GAP.julia_to_gap("Text")::Oscar.GAP.GapObj
+  prs = Oscar.GAP.Globals.ParseBibXMLextFiles(Oscar.GAP.GapObj(file))::Oscar.GAP.GapObj
+  txt = Oscar.GAP.GapObj("Text")::Oscar.GAP.GapObj
   for e in prs.entries
     r = Oscar.GAP.Globals.RecBibXMLEntry(e, txt, prs.strings)::Oscar.GAP.GapObj
     gdm_references[Oscar.GAP.gap_to_julia(r.Label)] = e
@@ -50,7 +50,7 @@ end
 load_references()
 
 function formatted_reference(label::AbstractString)
-  txt = Oscar.GAP.julia_to_gap("Text")
+  txt = Oscar.GAP.GapObj("Text")
   Globals = Oscar.GAP.Globals
   r = gdm_references[label]::Oscar.GAP.GapObj
   origin = Globals.StringBibXMLEntry(r, txt)

--- a/test/testcons.jl
+++ b/test/testcons.jl
@@ -56,10 +56,12 @@
 
     # The dimension of the matrix must fit.
     l1 = length(Chevie.charnames(Chevie.UnipotentCharacters(R), TeX = true))
-    obj = GenericDecMats.generic_decomposition_matrix(nam)
-    l2 = length(obj.ordinary)
-    if l1 != l2 && obj.is_complete == true
-      error("$nam: ordinary has length $l2 (should be $l1)")
+    for context in keys(GenericDecMats._decomposition_matrix_from_list)
+      obj = GenericDecMats.generic_decomposition_matrix(nam, context)
+      l2 = length(obj.ordinary)
+      if l1 != l2 && obj.is_complete == true
+        error("$nam: ordinary has length $l2 (should be $l1)")
+      end
     end
 
     # Let Chevie interpret the matrix.


### PR DESCRIPTION
- JSON is now at version 1.6, we had required 0.21, which is too small for Oscar.jl. (GenericDecMats.jl is a dependency of Chevie.jl, `Pkg.add("Chevie")` and `Pkg.add("Oscar")` results in a very old version of Oscar.jl that is content with JSON 0.21.)
- Call `Oscar.GAP.GapObj` instead of `Oscar.GAP.julia_to_gap` (since GAP.jl 0.12.0, released end of 2024).
- Call `Oscar.polynomial_ring`, `Oscar.ZZRingElem` instead of `Oscar.PolynomialRing`, `Oscar.fmpz`.
- Increase the version number from 0.1.2 to 0.1.3.

resolves #10